### PR TITLE
feat: add file renaming functionality with API documentation

### DIFF
--- a/docs/files_rename.md
+++ b/docs/files_rename.md
@@ -1,0 +1,56 @@
+````markdown
+# PUT /api/v1/files/:id
+
+Method: PUT (application/json)
+
+URL: /api/v1/files/:id
+
+Auth: Bearer (required)
+
+Body (application/json):
+
+- `new_name` (string, required) — desired new filename. If the provided name has no extension, the original file extension is preserved and appended automatically.
+
+Example request:
+
+```json
+{ "new_name": "report-2025" }
+```
+
+Behavior:
+
+- Only the file owner may rename the file. The server verifies ownership and returns an error if the authenticated user does not own the file.
+- The server renames the file on disk (moves it under the uploads base path) and updates the file metadata in the database (`filename`, `filepath`).
+- If a file already exists with the target name in the uploads folder, the request fails with a `400` error to avoid overwriting.
+- The server preserves the original file extension if the `new_name` does not include an extension.
+
+Successful response (200):
+
+```json
+{
+  "id": 15,
+  "user_id": 11,
+  "workspace_id": 3,
+  "file_name": "report-2025.pdf",
+  "file_path": "./uploads/report-2025.pdf",
+  "mime_type": "application/pdf",
+  "size": 12345,
+  "categories": [],
+  "created_at": "2025-12-17T12:34:56Z"
+}
+```
+
+Errors:
+
+- `400 Bad Request` — invalid `file id`, invalid JSON, target filename already exists, or unauthorized (file not owned by user).
+- `404 Not Found` — file not found.
+- `500 Internal Server Error` — filesystem or database errors while renaming.
+
+Notes for integrators:
+
+- Callers should provide only the desired name (without path). The server stores files inside the configured uploads directory.
+- If you need to preserve the original filename extension, you may omit the extension in `new_name` — the server will append the original extension automatically.
+
+See implementation: [internal/handlers/file_handler.go](internal/handlers/file_handler.go#L1) and [internal/services/file_service.go](internal/services/file_service.go#L1).
+
+````

--- a/internal/dto/file_dto.go
+++ b/internal/dto/file_dto.go
@@ -35,3 +35,7 @@ type StorageSummaryResponse struct {
 	RemainingBytes int64          `json:"remaining_bytes"`
 	LatestFiles    []FileResponse `json:"latest_files,omitempty"`
 }
+
+type RenameFileRequest struct {
+	NewName string `json:"new_name" binding:"required"`
+}

--- a/internal/handlers/file_handler.go
+++ b/internal/handlers/file_handler.go
@@ -316,3 +316,27 @@ func (h *FileHandler) StorageSummary(c *gin.Context) {
 
 	utils.RespondJSON(c, http.StatusOK, resp, "ok")
 }
+
+func (h *FileHandler) Rename(c *gin.Context) {
+	userID := c.GetUint("userID")
+	idParam := c.Param("id")
+	fileID, err := strconv.ParseUint(idParam, 10, 64)
+	if err != nil {
+		utils.RespondJSON(c, http.StatusBadRequest, nil, "invalid file id")
+		return
+	}
+
+	var req dto.RenameFileRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.RespondJSON(c, http.StatusBadRequest, nil, err.Error())
+		return
+	}
+
+	resp, err := h.FileService.RenameFile(userID, uint(fileID), req.NewName)
+	if err != nil {
+		utils.RespondJSON(c, http.StatusBadRequest, nil, err.Error())
+		return
+	}
+
+	utils.RespondJSON(c, http.StatusOK, resp, "file renamed successfully")
+}

--- a/internal/repositories/file_repository.go
+++ b/internal/repositories/file_repository.go
@@ -10,6 +10,7 @@ type FileRepositoryInterface interface {
 	Create(file *models.File) error
 	FindByID(id uint) (*models.File, error)
 	FindByIDWithCategories(id uint) (*models.File, error)
+	Update(file *models.File) error
 	ListUserFiles(userID uint) ([]models.File, error)
 	ListUserFilesWithCategories(userID uint) ([]models.File, error)
 	ListFilesByWorkspaceWithCategories(workspaceID uint) ([]models.File, error)
@@ -53,6 +54,10 @@ func (r *FileRepository) FindByIDWithCategories(id uint) (*models.File, error) {
 		return nil, err
 	}
 	return &file, nil
+}
+
+func (r *FileRepository) Update(file *models.File) error {
+	return r.db.Save(file).Error
 }
 
 func (r *FileRepository) ListUserFiles(userID uint) ([]models.File, error) {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -54,6 +54,7 @@ func InitRoutes(r *gin.Engine, db *gorm.DB) {
 			protected.GET("/files", fileHandler.ListMyFiles)
 			protected.GET("/files/:id", fileHandler.GetByID)
 			protected.DELETE("/files/:id", fileHandler.Delete)
+			protected.PUT("/files/:id", fileHandler.Rename)
 			protected.GET("/files/:id/download", fileHandler.Download)
 			protected.GET("/files/:id/thumbnail", fileHandler.Thumbnail)
 			protected.GET("/storage/summary", fileHandler.StorageSummary)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to rename their uploaded files via the API. It includes updates to the API documentation, handler, service, repository, and routing to support this functionality. The implementation ensures only file owners can rename files, prevents overwriting existing files, and preserves file extensions if not provided.

**File renaming feature:**

* Added a new API endpoint `PUT /api/v1/files/:id` for renaming files, with detailed documentation in `docs/files_rename.md`. The endpoint requires authentication, only allows the file owner to rename, preserves file extensions, and prevents overwriting existing files.
* Implemented the `Rename` handler in `FileHandler` to process rename requests, validate input, check ownership, and return appropriate responses.
* Added the `RenameFile` method to the `FileService` and its interface, handling business logic for renaming files on disk, updating metadata, and error handling. [[1]](diffhunk://#diff-f071753ec2bf15889e804aa7aedcf064e29f7c6fee602b01ad42023575c4993cR29) [[2]](diffhunk://#diff-f071753ec2bf15889e804aa7aedcf064e29f7c6fee602b01ad42023575c4993cR192-R246)
* Extended the repository interface and implementation with an `Update` method to persist file metadata changes. [[1]](diffhunk://#diff-ab08b6b2b3bfd86de727b525add31499ea759dac1d65183af04c0264709ee915R13) [[2]](diffhunk://#diff-ab08b6b2b3bfd86de727b525add31499ea759dac1d65183af04c0264709ee915R59-R62)
* Registered the new route in the API, enabling `PUT /files/:id` for authenticated users.

**Supporting changes:**

* Introduced a new DTO `RenameFileRequest` for request validation in `internal/dto/file_dto.go`.