### PR TITLE
feat: implement API key authentication middleware and update api key

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"vasvault/pkg/utils"
@@ -65,6 +66,29 @@ func GinBearerAuth() gin.HandlerFunc {
 
 		fmt.Println("Token claims.ID:", claims.ID)
 		c.Set("userID", claims.ID)
+		c.Next()
+	}
+}
+
+func GinAPIKeyAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		expected := os.Getenv("API_KEY")
+		if expected == "" {
+			c.Next()
+			return
+		}
+
+		key := c.GetHeader("x-api-key")
+		if key == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing x-api-key header"})
+			return
+		}
+
+		if key != expected {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
+			return
+		}
+
 		c.Next()
 	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -36,9 +36,9 @@ func InitRoutes(r *gin.Engine, db *gorm.DB) {
 		apiV1.POST("/register", userHandler.Register)
 		apiV1.POST("/refresh", userHandler.Refresh)
 
-		// Protected routes
+		// Protected routes (require API key + Bearer token)
 		protected := apiV1.Group("")
-		protected.Use(middleware.GinBearerAuth())
+		protected.Use(middleware.GinAPIKeyAuth(), middleware.GinBearerAuth())
 		{
 			protected.GET("/me", userHandler.Me)
 			protected.PUT("/profile", userHandler.UpdateProfile)


### PR DESCRIPTION
This pull request adds an API key authentication middleware to enhance the security of protected API routes. Now, protected endpoints require both a valid API key (via the `x-api-key` header) and a Bearer token for access.

**Authentication improvements:**

* Added a new `GinAPIKeyAuth` middleware in `auth.go` that checks for an `x-api-key` header and validates it against the `API_KEY` environment variable. If the key is missing or invalid, it returns an unauthorized error.
* Updated the protected API routes in `routes.go` to require both the new API key middleware and the existing Bearer token middleware, increasing security for sensitive endpoints.

**Dependency changes:**

* Imported the `os` package in `auth.go` to access environment variables for API key validation.…d routes